### PR TITLE
add container support, config file and volume support on the way...

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@
 *.dll
 *.so
 *.dylib
+# for linux binary
+filecloud
 
 # Test binary, built with `go test -c`
 *.test

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM golang:1.15.1-alpine3.12
+LABEL MAINTAINER="a nice guy"
+WORKDIR $GOPATH/src/github.com/yddeng/filecloud
+ADD . $GOPATH/src/github.com/yddeng/filecloud
+RUN go env -w GO111MODULE=auto && go env -w GOPROXY=https://goproxy.io && go build  -o filecloud server/main/filecloud.go
+ENTRYPOINT ["./filecloud", "config.toml"] 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ SaveFileMultiple 文件是否保存为多份。
 文件移动、拷贝。
 
 ## 启动
+一、使用本地二进制文件
 
 `go get github.com/yddeng/filecloud`
 
@@ -64,3 +65,12 @@ SaveFileMultiple = false         # 文件是否保存为多份。
 2. `go run server/main/filecloud.go config.toml` 
 
 3. 浏览器访问 webAddr。
+
+
+二、使用容器
+
+```sh
+docker build . -t  yddeng/filecloud:v0.1
+docker container run  --rm -p 9987:9987  yddeng/filecloud:v0.1
+```
+浏览器打开 `localhost:9987` 即可


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/8622915/100385600-0e4e3e80-305e-11eb-950c-a5f186f2888c.png)

增加对容器的支持
TODO：
1、可以用本地配置文件覆盖容器中配置文件
2、支持挂载本地 volume 作为存储路径
3、容器镜像上传 DockerHub